### PR TITLE
Invoke on instances instead of the class Point

### DIFF
--- a/06_object.txt
+++ b/06_object.txt
@@ -981,11 +981,11 @@ ifdef::html_target[]
 ----
 // Your code here.
 
-console.log(Point(1, 2).plus(Point(2, 3)));
+console.log(new Point(1, 2).plus(new Point(2, 3)));
 // → Point{x: 3, y: 5}
-console.log(Point(1, 2).minus(Point(2, 3)));
+console.log(new Point(1, 2).minus(new Point(2, 3)));
 // → Point{x: -1, y: -1}
-console.log(Point(3, 4).distance);
+console.log(new Point(3, 4).distance);
 // → 5
 ----
 endif::html_target[]


### PR DESCRIPTION
The book does read 'Give the Point prototype two methods', so it would make sense to instantiate Point objects and invoke methods on them instead of the constructor.
This worked for me, so I thought this might save some trouble for others.
