### PR TITLE
Fix export

### DIFF
--- a/code/ancestry.js
+++ b/code/ancestry.js
@@ -43,5 +43,5 @@ var ANCESTRY_FILE = "[\n  " + [
 // This makes sure the data is exported in node.js —
 // `require(./path/to/ancestry.js)` will get you the array.
 if (typeof module != "undefined" && module.exports)
-  module.exports = ancestry;
+  module.exports = ANCESTRY_FILE;
 


### PR DESCRIPTION
I tried to use `require('./ancestry.js')`, but I was getting the following error:

``` .../ancestry.js:46
  module.exports = ancestry;
                   ^
ReferenceError: ancestry is not defined
```
