### PR TITLE
Changed '\<=' to '<=' in Chapter 1

### DIFF
--- a/01_values.txt
+++ b/01_values.txt
@@ -349,7 +349,7 @@ codes of the characters one by one.
 
 (((>= operator)))(((<= operator)))(((== operator)))(((!=
 operator)))Other similar operators are `>=` (greater than or equal
-to), `\<=` (less than or equal to), `==` (equal to), and
+to), `<=` (less than or equal to), `==` (equal to), and
 `!=` (not equal to).
 
 [source,javascript]
@@ -578,7 +578,7 @@ Such values are created by typing in their name (`true`, `null`) or
 value (`13`, `"abc"`). You can combine and transform values with operators. We saw binary
 operators for arithmetic (`+`, `-`, `*`, `/`,
 and `%`), string concatenation (`+`), comparison (`==`, `!=`,
-`===`, `!==`, `<`, `>`, `\<=`, `>=`), and logic (`&&`, `||`), as well
+`===`, `!==`, `<`, `>`, `<=`, `>=`), and logic (`&&`, `||`), as well
 as several unary operators (`-` to negate a number, `!` to negate
 logically, and `typeof` to find a value's type).
 


### PR DESCRIPTION
I couldn't run `make html` and see the actual results since I am having trouble installing all the node dependencies, but hopefully it would render the html properly since it's already marked as code. 

Right now, it is rendered as `\<=` in html in both the places in Chapter 1. It should be rendered as `<=`.
