### PR TITLE
Fix minor typo in 03_functions

### DIFF
--- a/03_functions.txt
+++ b/03_functions.txt
@@ -360,7 +360,7 @@ top
 (((return keyword)))(((memory)))Because a function has to jump back to
 the place of the call when it returns, the computer must remember the
 context from which the function was called. In one case, `console.log`
-had to jump back to the `greet` function. In the other case, it jumps
+has to jump back to the `greet` function. In the other case, it jumps
 back to the end of the program.
 
 The place where the computer stores this context is the _((call


### PR DESCRIPTION
Fixes inconsistent verb tense use on line 363 of 03_functions.

Before: In one case, `console.log` [had] to jump back to the `greet` function. In the other case, it jumps back to the end of the program.
After: In one case, `console.log` [has] to jump back to the `greet` function. In the other case, it jumps back to the end of the program.

Use of "has" is consistent with the rest of the paragraph, which is written in present tense.
