### PR TITLE
Fix typo in Chapter 2

### DIFF
--- a/02_program_structure.txt
+++ b/02_program_structure.txt
@@ -891,7 +891,7 @@ headache.
 #######
 ----
 
-It may be useful to know that you can find the lengt of a string by
+It may be useful to know that you can find the length of a string by
 writing `.length` after it.
 
 [source,javascript]
@@ -980,13 +980,13 @@ should form a chess board.
 Passing this string to `console.log` should show something like this:
 
 ----
-# # # # 
+# # # #
  # # # #
-# # # # 
+# # # #
  # # # #
-# # # # 
+# # # #
  # # # #
-# # # # 
+# # # #
  # # # #
 ----
 


### PR DESCRIPTION
Fixed the typo: lengt -> length

My text-editor is set to remove blank spaces at line-ending by default - so that diff of chess-board is unintentional, but hopefully, that doesn't create any problems :-)
