### PR TITLE
Ch. 16: Allow smaller canvas for smaller level

### DIFF
--- a/16_canvas.txt
+++ b/16_canvas.txt
@@ -835,8 +835,8 @@ standing still, it keeps facing the direction it last moved in.
 ----
 function CanvasDisplay(parent, level) {
   this.canvas = document.createElement("canvas");
-  this.canvas.width = 600;
-  this.canvas.height = 450;
+  this.canvas.width = Math.min(600, level.width * scale);
+  this.canvas.height = Math.min(450, level.height * scale);
   parent.appendChild(this.canvas);
   this.cx = this.canvas.getContext("2d");
 


### PR DESCRIPTION
If a sufficiently small level is used in the canvas version of the game, the program will crash as it attempts to access non-existent squares from the level grid. The small level from Chapter 15, for example, will cause a crash.

This is one simple solution: make the canvas smaller if the level requires it.
