### PR TITLE
fix solution for 17_2

### DIFF
--- a/code/solutions/17_2_waiting_for_multiple_promises.js
+++ b/code/solutions/17_2_waiting_for_multiple_promises.js
@@ -17,7 +17,7 @@ function all(promises) {
 }
 
 // Test code.
-all([], function(array) {
+all([]).then(function(array) {
   console.log("This should be []:", array);
 });
 function soon(val) {


### PR DESCRIPTION
This example code wasn't working correctly-- the code called the callback as "succeed", while the promise constructor's argument was "success". Also, the first test was written like it expected a callback, while the all() function returns a promise.
