### PR TITLE
Fix findDate function month off by 1

### DIFF
--- a/09_regexp.txt
+++ b/09_regexp.txt
@@ -423,11 +423,11 @@ function findDate(string) {
   var dateTime = /(\d{1,2})-(\d{1,2})-(\d{4})/;
   var match = dateTime.exec(string);
   return new Date(Number(match[3]),
-                  Number(match[2]),
+                  Number(match[2] - 1),
                   Number(match[1]));
 }
 console.log(findDate("30-1-2003"));
-// → Sun Mar 02 2003 00:00:00 GMT+0100 (CET)
+// → Thu Jan 30 2003 00:00:00 GMT+0100 (CET)
 ----
 
 == Word and string boundaries ==


### PR DESCRIPTION
It's so true, having month numbers start at 0 _is_ confusing and silly.
