### PR TITLE
A small fix

### DIFF
--- a/04_data.txt
+++ b/04_data.txt
@@ -550,7 +550,7 @@ function phi(table) {
               (table[0] + table[2]));
 }
 
-console.log(phi([76, 9, 4, 1]));
+console.log(phi([76, 4, 9, 1]));
 // → 0.068599434
 ----
 


### PR DESCRIPTION
As per the decision/explanation in the example:

"We’ll interpret the indices to the array as two-bit binary number, where the rightmost digit refers to the squirrel variable and the leftmost digit refers to event variable. For example, the binary number 10 refers to the case where the event (say, "pizza") is true, but Jacques didn’t turn into a squirrel. And since binary 10 is 2 in decimal notation, we will store this value in the array at index 2."

Then the table array that is passed on that example should be [76, 4, 9, 1] instead of [76, 9, 4, 1]. The result of the phi() function isn't affected. If the table array passed to phi() in the example was instead [76, 9, 4, 1] then the phi function should be probably written as (but that move away from the decision made to interpret the indices to the array as two-bit binary numbers":

function phi(table) {
  return (table[3] \* table[0] - table[1] \* table[2]) /
    Math.sqrt((table[1] + table[3]) *
              (table[0] + table[2]) *
              (table[2] + table[3]) *
              (table[0] + table[1]));
}
