### PR TITLE
Add 'table-layout: fixed' to book's CSS in Ch. 15

### DIFF
--- a/15_game.txt
+++ b/15_game.txt
@@ -489,16 +489,18 @@ want:
 [source,text/css]
 ----
 .background    { background: rgb(52, 166, 251);
+                 table-layout: fixed;
                  border-spacing: 0;              }
 .background td { padding: 0;                     }
 .lava          { background: rgb(255, 100, 100); }
 .wall          { background: white;              }
 ----
 
-(((padding (CSS))))Some of these (`border-spacing`
+(((padding (CSS))))Some of these (`table-layout`, `border-spacing`, 
 and `padding`) are simply used to suppress unwanted default behavior.
-We don't want space between the ((table)) cells or padding inside
-them.
+We don't want the layout of the ((table)) to depend upon the contents 
+of its cells, and we don't want space between the ((table)) cells or 
+padding inside them.
 
 (((background (CSS))))(((rgb (CSS))))(((CSS)))The `background` rule
 sets the background color. CSS allows colors to be specified both as


### PR DESCRIPTION
This commit adds a line -- 'table-layout:fixed' -- to the
'.background' CSS displayed in the book's Chapter 15 ('Project: A
Platform Game'). This line is required in order for the game to
function properly in Google Chrome (at least versions 38 and 39). If
the line is not included, Google Chrome's table layout algorithm can
alter the size of the table cells constituting the game's background,
resulting in buggy behavior (e.g., the player will 'hit' walls before
the player icon is actually touching a displayed wall).

The relevant line is already included in the downloadable code for the
book. This commit simply adds it, together with a brief explanation, to
the CSS displayed in the book text, so that readers who are typing
along with the book will end up with a working game.
