### PR TITLE
Update 06_2_another_cell.js

### DIFF
--- a/code/solutions/06_2_another_cell.js
+++ b/code/solutions/06_2_another_cell.js
@@ -11,7 +11,7 @@ StretchCell.prototype.minHeight = function() {
   return Math.max(this.height, this.inner.minHeight());
 };
 StretchCell.prototype.draw = function(width, height) {
-  return this.inner.draw(width, height);
+  return this.inner.draw(this.minWidth(), this.minHeight());
 };
 
 var sc = new StretchCell(new TextCell("abc"), 1, 2);


### PR DESCRIPTION
If you want to insure that the resulting cell has at least the given width and height, even if the inner cell would be smaller shouldn't draw call the minWidth() and minHeight() methods?