### PR TITLE
maybe a bug in conway's game of life?

### DIFF
--- a/code/solutions/18_3_conways_game_of_life.html
+++ b/code/solutions/18_3_conways_game_of_life.html
@@ -44,7 +44,7 @@
     var count = 0;
     for (var y1 = Math.max(0, y - 1); y1 <= Math.min(height, y + 1); y1++) {
       for (var x1 = Math.max(0, x - 1); x1 <= Math.min(width, x + 1); x1++) {
-        if ((x1 != x || y1 != y) && grid[x1 + y1 * width])
+        if ((x1 != x || y1 != y) && grid[x1 + y1 * width] && x1!=width)
           count +=1 ;
       }
     }


### PR DESCRIPTION
Hi Marijn,
When count neighbors, the cells at the end of right would count with the cells at the start of next row.
![20150506141703](https://cloud.githubusercontent.com/assets/5820143/7488281/a30642bc-f3fa-11e4-968a-9aaa16f413c2.png)
in the end of the inner loop, 'x1' will be 'width', then 'x1+y1*width' will be next row. So I ignore this condition.