### PR TITLE
fix variable name in 09_regexp.txt

### DIFF
--- a/09_regexp.txt
+++ b/09_regexp.txt
@@ -936,7 +936,7 @@ while (match = number.exec(input))
 
 (((while loop)))(((= operator)))This makes use of the fact that the
 value of an ((assignment)) expression (`=`) is the assigned value. So
-by using `match = re.exec(input)` as the condition in the `while`
+by using `match = number.exec(input)` as the condition in the `while`
 statement, we perform the match at the start of each iteration, save
 its result in a ((variable)), and stop looping when no more matches
 are found.


### PR DESCRIPTION
Hi, on [L930](https://github.com/marijnh/Eloquent-JavaScript/blob/master/09_regexp.txt#L930) you have the following code with a variable called 'number'
> `while (match = number.exec(input))`

On [L939](https://github.com/marijnh/Eloquent-JavaScript/blob/master/09_regexp.txt#L939) you reference this code, but use a variable called 're' instead of 'number'
> So by using `match = re.exec(input)` as the condition in the `while` statement

**Ps Thank you for this excellent book!**