### PR TITLE
remove 'checked' attribute from file input

### DIFF
--- a/18_forms.txt
+++ b/18_forms.txt
@@ -64,7 +64,7 @@ JavaScript, we often do not want to submit our fields normally anyway.
 <p><input type="radio" value="A" name="choice">
    <input type="radio" value="B" name="choice" checked>
    <input type="radio" value="C" name="choice"> (radio)</p>
-<p><input type="file" checked> (file)</p>
+<p><input type="file"> (file)</p>
 ----
 
 ifdef::book_target[]


### PR DESCRIPTION
The **checked** attribute is only for *radio* or *checkbox*, otherwise it is ignored.
For the *file* type you can add the **multiple** or **accept** attributes for example.
[MDN input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input)