### PR TITLE
Rename act method parameter in Chapter 7

### DIFF
--- a/07_elife.txt
+++ b/07_elife.txt
@@ -943,9 +943,9 @@ First we'll write a ((plant)), which is a rather simple life-form.
 function Plant() {
   this.energy = 3 + Math.random() * 4;
 }
-Plant.prototype.act = function(context) {
+Plant.prototype.act = function(view) {
   if (this.energy > 15) {
-    var space = context.find(" ");
+    var space = view.find(" ");
     if (space)
       return {type: "reproduce", direction: space};
   }
@@ -971,11 +971,11 @@ now define a plant eater.
 function PlantEater() {
   this.energy = 20;
 }
-PlantEater.prototype.act = function(context) {
-  var space = context.find(" ");
+PlantEater.prototype.act = function(view) {
+  var space = view.find(" ");
   if (this.energy > 60 && space)
     return {type: "reproduce", direction: space};
-  var plant = context.find("*");
+  var plant = view.find("*");
   if (plant)
     return {type: "eat", direction: plant};
   if (space)

--- a/code/solutions/07_1_artificial_stupidity.js
+++ b/code/solutions/07_1_artificial_stupidity.js
@@ -2,14 +2,14 @@ function SmartPlantEater() {
   this.energy = 30;
   this.direction = "e";
 }
-SmartPlantEater.prototype.act = function(context) {
-  var space = context.find(" ");
+SmartPlantEater.prototype.act = function(view) {
+  var space = view.find(" ");
   if (this.energy > 90 && space)
     return {type: "reproduce", direction: space};
-  var plants = context.findAll("*");
+  var plants = view.findAll("*");
   if (plants.length > 1)
     return {type: "eat", direction: randomElement(plants)};
-  if (context.look(this.direction) != " " && space)
+  if (view.look(this.direction) != " " && space)
     this.direction = space;
   return {type: "move", direction: this.direction};
 };

--- a/code/solutions/07_2_predators.js
+++ b/code/solutions/07_2_predators.js
@@ -2,14 +2,14 @@ function SmartPlantEater() {
   this.energy = 30;
   this.direction = "e";
 }
-SmartPlantEater.prototype.act = function(context) {
-  var space = context.find(" ");
+SmartPlantEater.prototype.act = function(view) {
+  var space = view.find(" ");
   if (this.energy > 90 && space)
     return {type: "reproduce", direction: space};
-  var plants = context.findAll("*");
+  var plants = view.findAll("*");
   if (plants.length > 1)
     return {type: "eat", direction: randomElement(plants)};
-  if (context.look(this.direction) != " " && space)
+  if (view.look(this.direction) != " " && space)
     this.direction = space;
   return {type: "move", direction: this.direction};
 };
@@ -20,12 +20,12 @@ function Tiger() {
   // Used to track the amount of prey seen per turn in the last six turns
   this.preySeen = [];
 }
-Tiger.prototype.act = function(context) {
+Tiger.prototype.act = function(view) {
   // Average number of prey seen per turn
   var seenPerTurn = this.preySeen.reduce(function(a, b) {
     return a + b;
   }, 0) / this.preySeen.length;
-  var prey = context.findAll("O");
+  var prey = view.findAll("O");
   this.preySeen.push(prey.length);
   // Drop the first element from the array when it is longer than 6
   if (this.preySeen.length > 6)
@@ -35,10 +35,10 @@ Tiger.prototype.act = function(context) {
   if (prey.length && seenPerTurn > 0.25)
     return {type: "eat", direction: randomElement(prey)};
     
-  var space = context.find(" ");
+  var space = view.find(" ");
   if (this.energy > 400 && space)
     return {type: "reproduce", direction: space};
-  if (context.look(this.direction) != " " && space)
+  if (view.look(this.direction) != " " && space)
     this.direction = space;
   return {type: "move", direction: this.direction};
 };


### PR DESCRIPTION
* For coherence with BouncingCritter and WallFollower act methods.
* To avoid unnecessary confusion with Grid.prototype.forEach, which receives an actual context.