### PR TITLE
forceDirected_novector is repeated in 22_fast.js

### DIFF
--- a/code/chapter/22_fast.js
+++ b/code/chapter/22_fast.js
@@ -119,7 +119,7 @@ function forceDirected_novector(graph) {
   }
 }
 
-function forceDirected_novector(graph) {
+function forceDirected_localforce(graph) {
   var forcesX = [], forcesY = [];
   for (var i = 0; i < graph.length; i++)
    forcesX[i] = forcesY[i] = 0;


### PR DESCRIPTION
Renamed the second one to forceDirected_localforce, as listed in the printed book.