### PR TITLE
Added .mobi (Kindle) Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 /epub/img/*
 /epub/content.opf
 /book.epub
+/book.mobi

--- a/Makefile
+++ b/Makefile
@@ -118,3 +118,6 @@ epub/hints.xhtml: $(foreach CHAP,$(CHAPTERS),$(CHAP).txt) bin/extract_hints.js
 
 epubcheck: book.epub
 	epubcheck book.epub 2>&1 | grep -v 'img/.*\.svg'
+
+book.mobi:
+	ebook-convert book.epub book.mobi --output-profile=kindle --remove-first-image

--- a/Makefile
+++ b/Makefile
@@ -119,5 +119,5 @@ epub/hints.xhtml: $(foreach CHAP,$(CHAPTERS),$(CHAP).txt) bin/extract_hints.js
 epubcheck: book.epub
 	epubcheck book.epub 2>&1 | grep -v 'img/.*\.svg'
 
-book.mobi:
-	ebook-convert book.epub book.mobi --output-profile=kindle --remove-first-image
+book.mobi: book.epub img/cover.png
+	ebook-convert book.epub book.mobi --output-profile=kindle --cover=img/cover.png --remove-first-image

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Feedback welcome, in the form of issues and pull requests.
 ## Building
 
     npm install --production
-    apt-get install asciidoc inkscape
+    apt-get install asciidoc inkscape calibre
     make html
 
 For OSX, you can use port or brew to install the asciidoc package.
@@ -21,3 +21,7 @@ To build the PDF file:
 To build the ePub book:
 
     make book.epub
+
+To build a mobi book from the epub book:
+
+    make book.mobi

--- a/html/index.html
+++ b/html/index.html
@@ -98,6 +98,7 @@
     <li><a href="errata.html">Errata for the paper book</a></li>
     <li><a href="http://eloquentjavascript.net/Eloquent_JavaScript.pdf">This book as a single PDF file</a> (&amp; <a href="http://eloquentjavascript.net/Eloquent_JavaScript_small.pdf">small version for mobile</a>)</li>
     <li><a href="http://eloquentjavascript.net/Eloquent_JavaScript.epub">This book as an EPUB file</a></li>
+    <li><a href="http://eloquentjavascript.net/Eloquent_JavaScript.mobi">This book as an MOBI (Kindle) file</a></li>
     <li><a href="http://eloquentjavascript.net/1st_edition">The first edition of the book</a></li>
   </ul>
 


### PR DESCRIPTION
Support for .mobi format.

* README updated
* Makefile now has ‘make book.mobi’
* Website updated with link to .mobi format.

This works great. It’s simply uses Calibre to convert to ePub to MOBI.

However, before updating http://eloquentjavascript.net/ you need to make sure this file exists on the server http://eloquentjavascript.net/Eloquent_JavaScript.mobi. I could not find anywhere in the code where this file was generate automatically.