### PR TITLE
add reverse count w/o step to 4.1

### DIFF
--- a/code/solutions/04_1_the_sum_of_a_range.js
+++ b/code/solutions/04_1_the_sum_of_a_range.js
@@ -1,15 +1,16 @@
 function range (start, end, step) {
     var array = [];
-    if (start < end)
+    if (start < end) {
       if (step == null)
         step = 1;
       for (var i = start; i <= end; i += step)
         array.push(i);
-    else
+    } else {
       if (step == null)
         step = -1;
       for (var i = start; i >= end; i+= step)
         array.push(i);
+    }
     return array;
 }
 

--- a/code/solutions/04_1_the_sum_of_a_range.js
+++ b/code/solutions/04_1_the_sum_of_a_range.js
@@ -1,15 +1,16 @@
-function range(start, end, step) {
-  if (step == null) step = 1;
-  var array = [];
-
-  if (step > 0) {
-    for (var i = start; i <= end; i += step)
-      array.push(i);
-  } else {
-    for (var i = start; i >= end; i += step)
-      array.push(i);
-  }
-  return array;
+function range (start, end, step) {
+    var array = [];
+    if (start < end)
+      if (step == null)
+        step = 1;
+      for (var i = start; i <= end; i += step)
+        array.push(i);
+    else
+      if (step == null)
+        step = -1;
+      for (var i = start; i >= end; i+= step)
+        array.push(i);
+    return array;
 }
 
 function sum(array) {
@@ -25,3 +26,5 @@ console.log(range(5, 2, -1));
 // → [5, 4, 3, 2]
 console.log(sum(range(1, 10)));
 // → 55
+console.log(range(10,1));
+// → [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]


### PR DESCRIPTION
Hi there!

I noticed that in exercise 4.1, for the bonus assignment, the range function doesn’t count down unless you provide a negative step. If you omit, it returns an empty array.

When you said to make sure the function works with negative step values, I just assumed that meant I also had to accommodate the case where start > end and no step value is provided. However, on checking my work and rereading the problem, I realized this wasn’t required and I’d just made a silly assumption. 

I assume you’re aware of this — I’m well aware I’m a beginner :) — but figured I’d update the solution in case it helps. Apologies if toe-stepping. 

Thanks!

PS Thank you so much for writing this book. I’m totally new to JS and have been working through your book to teach myself programming outside of work. Your book’s been incredibly useful and well-written. 

