### PR TITLE
Fix CodeMirror line numbers

### DIFF
--- a/html/css/ejs.css
+++ b/html/css/ejs.css
@@ -326,6 +326,7 @@ blockquote footer:before {
   height: auto;
   line-height: 1.35;
   border-top: 1px solid #4ab;
+  overflow-wrap: normal;
 }
 .CodeMirror-scroll {
   max-height: 700px;


### PR DESCRIPTION
The line numbers in CodeMirror editor could show incorrectly because of
the `overflow-wrap: break-word` introduced in 26d7e2f.

Set the `normal` `overflow-wrap` on the editor to prevent this problem.

Before:
![before](https://cloud.githubusercontent.com/assets/2908/24623946/83931622-18aa-11e7-95ac-59c734a05c65.png)

After:
![after](https://cloud.githubusercontent.com/assets/2908/24623952/88155552-18aa-11e7-9323-603671e5d083.png)
