### PR TITLE
Fixed bug where reduce returns NaN if optional argument isn't provided

### DIFF
--- a/05_higher_order.txt
+++ b/05_higher_order.txt
@@ -561,7 +561,7 @@ straightforward than `filter` and `map`, so pay close attention.
 [source,javascript]
 ----
 function reduce(array, combine, start) {
-  var current = start;
+  var current = start || 0;
   for (var i = 0; i < array.length; i++)
     current = combine(current, array[i]);
   return current;


### PR DESCRIPTION
From the book:
> If your array contains at least one element, you are allowed to leave off the start argument. The method will take the first element of the array as its start value and start reducing at the second element.

In the example reduce function, reduce will return NaN if the optional *start* argument isn't defined. As a fix, I set *current* to equal 0 if *start* is undefined.

This might not be the most correct fix because according to the text, if *start* is left out, *current* should equal the first element in the array and then start reducing at the second element. 