### PR TITLE
Clear sandbox console by replacing the whole div

### DIFF
--- a/html/js/sandbox.js
+++ b/html/js/sandbox.js
@@ -290,10 +290,12 @@
     this.div = div;
   };
 
-  var safari = /Safari\//.test(navigator.userAgent);
-
   Output.prototype = {
-    clear: function() { this.div.innerHTML = ""; },
+    clear: function() {
+      var clone = this.div.cloneNode(false);
+      this.div.parentNode.replaceChild(clone, this.div);
+      this.div = clone;
+    },
     out: function(type, args) {
       var wrap = document.createElement("pre");
       wrap.className = "sandbox-output-" + type;
@@ -306,8 +308,6 @@
           wrap.appendChild(represent(arg, 58));
       }
       this.div.appendChild(wrap);
-      if (safari)
-        setTimeout(function() { this.div.style.minHeight = ".1em"; }.bind(this), 50);
     }
   };
 


### PR DESCRIPTION
Even with the original fix for #66, the sandbox didn't work for me on
macOS 10.12.4. On a hunch (the problem appeared only after clearing the
non-empty output once, so...), I've tried different methods of clearing
the output, found on StackOverflow (hey, I'm learning! Great book BTW)
instead of trying to nudge the output to reappear as in the original
fix. This seems to work for me, at least with the latest browsers on
macOS and Windows 10.