### PR TITLE
require should be passed a string

### DIFF
--- a/code/ancestry.js
+++ b/code/ancestry.js
@@ -41,6 +41,6 @@ var ANCESTRY_FILE = JSON.stringify([
 ])
 
 // This makes sure the data is exported in node.js —
-// `require(./path/to/ancestry.js)` will get you the array.
+// `require("./path/to/ancestry.js")` will get you the array.
 if (typeof module != "undefined" && module.exports)
   module.exports = ANCESTRY_FILE;


### PR DESCRIPTION
Think there's a small typo in `ancestry.js` that might trip up people not familiar with JavaScript or Node.js.