### PR TITLE
Fix #153 Cover image doesn't show up with epub in iBooks

### DIFF
--- a/epub/content.opf.src
+++ b/epub/content.opf.src
@@ -12,6 +12,7 @@
     <link rel="cc:license" href="http://creativecommons.org/licenses/by-nc/3.0/"/>
     <meta property="cc:attributionURL">http://eloquentjavascript.net/</meta>
     <meta property="dcterms:modified">2014-09-04T10:47:00Z</meta>
+    <meta name="cover" content="image.cover.png" />
   </metadata>
   <manifest>
     <item id="titlepage" href="titlepage.xhtml" media-type="application/xhtml+xml"/>

--- a/epub/content.opf.src
+++ b/epub/content.opf.src
@@ -12,7 +12,7 @@
     <link rel="cc:license" href="http://creativecommons.org/licenses/by-nc/3.0/"/>
     <meta property="cc:attributionURL">http://eloquentjavascript.net/</meta>
     <meta property="dcterms:modified">2014-09-04T10:47:00Z</meta>
-    <meta name="cover" content="image.cover.png" />
+    <meta name="cover" content="img/cover.png" />
   </metadata>
   <manifest>
     <item id="titlepage" href="titlepage.xhtml" media-type="application/xhtml+xml"/>


### PR DESCRIPTION
iBooks needs the following meta tag:

    <meta name="cover" content="image.cover.png" />

in `content.opf` in order to display the cover.

Fixes #153 