### PR TITLE
Fix cover meta tag content value

### DIFF
--- a/epub/content.opf.src
+++ b/epub/content.opf.src
@@ -12,7 +12,7 @@
     <link rel="cc:license" href="http://creativecommons.org/licenses/by-nc/3.0/"/>
     <meta property="cc:attributionURL">http://eloquentjavascript.net/</meta>
     <meta property="dcterms:modified">2014-09-04T10:47:00Z</meta>
-    <meta name="cover" content="img/cover.png" />
+    <meta name="cover" content="image.cover.png" />
   </metadata>
   <manifest>
     <item id="titlepage" href="titlepage.xhtml" media-type="application/xhtml+xml"/>


### PR DESCRIPTION
This is the correct setting for displaying the book's cover in iBooks. I tested locally compiling the epub file. Sorry about the confusion.