### PR TITLE
Add escape characters to build index without errors

### DIFF
--- a/src/render_latex.js
+++ b/src/render_latex.js
@@ -31,12 +31,26 @@ function escapeChar(ch) {
     default: return "\\" + ch
   }
 }
-function escape(str) { return str.replace(/[&%$#_{}~^\\]/g, escapeChar) }
+function escapeIndexChar(ch) {
+  switch (ch) {
+    case "~": return "\\textasciitilde "
+    case "^": return "\\textasciicircum "
+    case "\\": return "\\textbackslash "
+    case "|": return "\\textbar{} "
+    case "@": return "\"@"
+    case "!": return "\"!"
+    default: return "\\" + ch
+  }
+}
+function escape(str, isIndex) {
+  if (isIndex) return str.replace(/[&%$#_{}~^\\|!@]/g, escapeIndexChar)
+  return str.replace(/[&%$#_{}~^\\]/g, escapeChar)
+}
 function miniEscape(str) { return str.replace(/[`]/g, escapeChar) }
 
 function escapeIndex(value) {
-  if (Array.isArray(value)) return value.map(escape).join("!")
-  return escape(String(value))
+  if (Array.isArray(value)) return value.map(item => escape(item, true)).join("!")
+  return escape(String(value), true)
 }
 
 function highlight(lang, text) {


### PR DESCRIPTION
Exclamation mark and vertical bar should be escaped.
```
This is makeindex, version 2.15 [TeX Live 2017] (kpathsea + Thai support).
Scanning input file book.idx........done (4943 entries accepted, 0 rejected).
Sorting entries................................................done (67129 comparisons).
Generating output file book.ind........done (2425 lines written, 0 warnings).
Output written in book.ind.
Transcript written in book.ilg.
```