### PR TITLE
Remove unnecessary parameter in chapter 5

### DIFF
--- a/05_higher_order.md
+++ b/05_higher_order.md
@@ -186,7 +186,7 @@ want to create a function value on the spot instead.
 
 ```
 let message = "Wow";
-repeat(5, i => {
+repeat(5, () => {
   message += "!";
 });
 console.log(message);


### PR DESCRIPTION
Arrow function in "Abstracting Repetition" has a parameter that isn't
used. Would be more clear to pass an empty parameter list.

Fixes #326