### PR TITLE
Prevent automatic conversion of -- operator to en dash in index

### DIFF
--- a/src/render_latex.js
+++ b/src/render_latex.js
@@ -44,12 +44,15 @@ function escapeIndexChar(ch) {
     case "|": return "\\textbar{} "
     case "@": return "\"@"
     case "!": return "\"!"
+    case "- ": return "-@− "
+    case "--": return "--@−−"
+    case "-=": return "-=@−="
     default: return "\\" + ch
   }
 }
 function escapeIndex(value) {
   if (Array.isArray(value)) return value.map(escapeIndex).join("!")
-  return String(value).replace(/[&%$#_{}~^\\|!@]/g, escapeIndexChar)
+  return String(value).replace(/[&%$#_{}~^\\|!@]|-[ -=]/g, escapeIndexChar)
 }
 
 function escapeComplexScripts(string) {


### PR DESCRIPTION
![screenshot-2018-2-16 eloquent_javascript pdf](https://user-images.githubusercontent.com/15799058/36321372-f12b7324-1349-11e8-9804-957832e559a1.png)

If you do not want minus sign instead of hyphen use `case "--": return "--@-{}-"`