### PR TITLE
PDF improvements

### DIFF
--- a/pdf/book.tex
+++ b/pdf/book.tex
@@ -65,7 +65,7 @@
 \newunicodechar{⮪}{\emojifont{⮪}}
 
 \graphicspath{{../}}
-\definecolor{coveryellow}{rgb}{0.996,0.839,0.122}
+\definecolor{coveryellow}{rgb}{0.997,0.840,0.122}
 
 \makeindex
 

--- a/pdf/book.tex
+++ b/pdf/book.tex
@@ -1,7 +1,7 @@
 \documentclass[fontsize=13pt,oneside,headings=small,chapterprefix]{scrbook}
 \usepackage{listings}
 \usepackage{graphicx}
-\usepackage[hidelinks]{hyperref}
+\PassOptionsToPackage{hyphens}{url}\usepackage[hidelinks]{hyperref}
 \usepackage{natbib}
 \usepackage{scrhack}
 \usepackage{charter}

--- a/src/render_latex.js
+++ b/src/render_latex.js
@@ -98,13 +98,16 @@ let renderer = {
   paragraph_close() { return "" },
 
   heading_open(token) {
-    if (token.tag == "h1") return `\\label{${chapter[1]}}${/^00/.test(file) || chapter[1] === "hints" ? "\\addchap" : "\\chapter"}{`
+    if (token.tag == "h1") return `${/^00/.test(file) || chapter[1] === "hints" ? "\\addchap" : "\\chapter"}{`
     if (token.tag == "h2") return `\n\n${id(token)}\\section{`
     if (token.tag == "h3") return `\n\n${id(token)}\\subsection{`
     if (token.tag == "h4") return `\n\n${id(token)}\\subsubsection{`
     throw new Error("Can't handle heading tag " + token.tag)
   },
-  heading_close() { return `}` },
+  heading_close(token) { 
+    if (token.tag == "h1") return `}\\label{${chapter[1]}}`
+    return `}` 
+  },
 
   bullet_list_open() { return `\n\n\\begin{itemize}` },
   bullet_list_close() { return `\n\\end{itemize}` },

--- a/src/render_latex.js
+++ b/src/render_latex.js
@@ -98,7 +98,7 @@ let renderer = {
   paragraph_close() { return "" },
 
   heading_open(token) {
-    if (token.tag == "h1") return `\\label{${chapter[1]}}\\chapter${/^00/.test(file) ? "*" : ""}{`
+    if (token.tag == "h1") return `\\label{${chapter[1]}}${/^00/.test(file) || chapter[1] === "hints" ? "\\addchap" : "\\chapter"}{`
     if (token.tag == "h2") return `\n\n${id(token)}\\section{`
     if (token.tag == "h3") return `\n\n${id(token)}\\subsection{`
     if (token.tag == "h4") return `\n\n${id(token)}\\subsubsection{`


### PR DESCRIPTION
- it uses KOMA-Script `\addchap` command for Introduction and Hints chapters
- it seems that it produces the same color as cover.jpg
- it breaks Amazon link to newline
- labels before chapter titles are a bad idea (try links at page 8)