### PR TITLE
Add `type` attribute to <link> tag in epub

### DIFF
--- a/epub/frontmatter.xhtml
+++ b/epub/frontmatter.xhtml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" lang="en-US">
   <head>
-    <link rel="stylesheet" href="style.css"/>
+    <link rel="stylesheet" href="style.css" type="text/css"/>
     <title>Eloquent JavaScript</title>
     <style>
       img.logo { vertical-align: text-top; padding: 0px 4px; border: 0; }

--- a/epub/titlepage.xhtml
+++ b/epub/titlepage.xhtml
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" lang="en-US">
   <head>
     <title>Cover</title>
-    <link rel="stylesheet" href="style.css"/>
+    <link rel="stylesheet" href="style.css" type="text/css"/>
     <style type="text/css" title="override_css">
       @page {padding: 0pt; margin:0pt}
       body { text-align: center; padding:0pt; margin: 0pt; }

--- a/epub/toc.xhtml.src
+++ b/epub/toc.xhtml.src
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" lang="en-US">
   <head>
     <title>Table of Contents</title>
-    <link rel="stylesheet" href="style.css"/>
+    <link rel="stylesheet" href="style.css" type="text/css"/>
     <style>
       nav#toc { display: none; }
 

--- a/src/epub_chapter.html
+++ b/src/epub_chapter.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" lang="en-US">
   <head>
     <title><<t $in.title>></title>
-    <link rel="stylesheet" href="style.css"/>
+    <link rel="stylesheet" href="style.css" type="text/css"/>
   </head>
   <body>
     <article>


### PR DESCRIPTION
This enables generating correct mobi files with [kindlegen](https://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000765211). It seems that without `type` attribute Kindle ignores all styles.

Now `ebook-convert` generates only old mobi format. This can be changed with option [`--mobi-file-type=both`](https://manual.calibre-ebook.com/generated/en/ebook-convert.html#cmdoption-ebook-convert-mobi-output-mobi-file-type). However, I prefer kindlegen because hybrid file generated witch `ebook-convert` and sent to Kindle by e-mail has broken SVG images (all SVGs with CSS styles are [black](https://user-images.githubusercontent.com/15799058/37143328-21c07252-22bb-11e8-9c34-87904c245a33.png)). The same file transferred via USB looks good.