### PR TITLE
Remove spurious quotes/commas

### DIFF
--- a/code/solutions/12_4_fixing_scope.js
+++ b/code/solutions/12_4_fixing_scope.js
@@ -15,9 +15,9 @@ specialForms.set = (args, env) => {
 };
 
 run(`
-do(define(x, 4),",
-   define(setx, fun(val, set(x, val))),",
-   setx(50),",
+do(define(x, 4),
+   define(setx, fun(val, set(x, val))),
+   setx(50),
    print(x))
 `);
 // → 50


### PR DESCRIPTION
The Egg program that tests the new `set` function contains extra `",` at the end of three lines, which throws a `SyntaxError`; this commit removes them.