### PR TITLE
Fix ReferenceError in chapter 11 exercise 1 

### DIFF
--- a/11_async.md
+++ b/11_async.md
@@ -1276,7 +1276,7 @@ function locateScalpel2(nest) {
   // Your code here.
 }
 
-locateScalpel(nest).then(console.log);
+locateScalpel(bigOak).then(console.log);
 // → Butcher Shop
 ```
 


### PR DESCRIPTION
The solution stubs indicate that the functions take nest values, whereas the function call later on needs to call with a specific nest, like bigOak. The error might make it unclear for someone studying promises for the first time, as the tests didn't require modification before.