### PR TITLE
Fix singular/plural glitch in level description in Chapter 16

### DIFF
--- a/16_game.md
+++ b/16_game.md
@@ -133,7 +133,7 @@ var simpleLevelPlan = `
 
 Periods are empty space, hash ("#") characters are walls, and plus
 signs are lava. The ((player))'s starting position is the ((at sign))
-(`@`). Every O characters is a coin, and the equals sign (`=`) at the
+(`@`). Every "o" character is a coin, and the equals sign (`=`) at the
 top is a block of lava that moves back and forth horizontally.
 
 {{index bouncing}}


### PR DESCRIPTION
In the description of the human-editable level format, "Every O characters is a coin" needs some adjustment:  at present it reads as if O is a variable that specifies an inter-coin distance.  I have proposed a fix.