### PR TITLE
Reword reference to code snippet in Chapter 15

### DIFF
--- a/15_event.md
+++ b/15_event.md
@@ -64,8 +64,8 @@ argument occurs.
 
 {{index "addEventListener method", "event handling", "window object"}}
 
-Each ((browser)) event handler is registered in a context. We called
-`addEventListener` on the `window` object before to register a handler
+Each ((browser)) event handler is registered in a context. Just now we called
+`addEventListener` on the `window` object to register a handler
 for the whole window. Such a method can also be found on ((DOM))
 elements and some other types of objects. Event listeners are only
 called when the event happens in the context of the object they are


### PR DESCRIPTION
I found the sentence a little hard to read when I hit the word "before", so I wanted to move the reference to another part of the sentence.  Since the event being referred to just happened, I used a different phrasing too.