### PR TITLE
Update 6.3 solution to match code from 6.2

### DIFF
--- a/code/solutions/06_3_iterable_groups.js
+++ b/code/solutions/06_3_iterable_groups.js
@@ -4,7 +4,7 @@ class Group {
   }
 
   add(value) {
-    if (!this.members.includes(value)) {
+    if (!this.has(value)) {
       this.members.push(value);
     }
   }


### PR DESCRIPTION
In the solution for 6.2 you used the 'this.has(value)' method, instead of 'this.members.includes(value)' in the 'add(value)' method.

The code should be consistent considering the exercise says:
// Your code here (and the code from the previous exercise)