### PR TITLE
Use Ctrl-' as close editor shortcut

### DIFF
--- a/html/js/ejs.js
+++ b/html/js/ejs.js
@@ -135,7 +135,7 @@ window.addEventListener("load", () => {
                  ["Revert to original code", () => revertCode(data)],
                  ["Reset sandbox (ctrl/cmd-esc)", () => resetSandbox(data.sandbox)]]
     if (!data.isHTML || !data.sandbox)
-      items.push(["Deactivate editor (ctrl-`)", () => { closeCode(data) }])
+      items.push(["Deactivate editor (ctrl-')", () => { closeCode(data) }])
     items.forEach(choice => menu.appendChild(elt("div", choice[0])))
     function click(e) {
       let target = e.target

--- a/html/js/ejs.js
+++ b/html/js/ejs.js
@@ -68,7 +68,7 @@ window.addEventListener("load", () => {
     Esc(cm) { cm.display.input.blur() },
     "Ctrl-Enter"(cm) { runCode(cm.state.context) },
     "Cmd-Enter"(cm) { runCode(cm.state.context) },
-    "Ctrl-`"(cm) { closeCode(cm.state.context) },
+    "Ctrl-'"(cm) { closeCode(cm.state.context) },
     "Ctrl-Esc"(cm) { resetSandbox(cm.state.context.sandbox) },
     "Cmd-Esc"(cm) { resetSandbox(cm.state.context.sandbox) }
   }

--- a/html/js/ejs.js
+++ b/html/js/ejs.js
@@ -68,7 +68,7 @@ window.addEventListener("load", () => {
     Esc(cm) { cm.display.input.blur() },
     "Ctrl-Enter"(cm) { runCode(cm.state.context) },
     "Cmd-Enter"(cm) { runCode(cm.state.context) },
-    "Ctrl-'"(cm) { closeCode(cm.state.context) },
+    "Ctrl-Down"(cm) { closeCode(cm.state.context) },
     "Ctrl-Esc"(cm) { resetSandbox(cm.state.context.sandbox) },
     "Cmd-Esc"(cm) { resetSandbox(cm.state.context.sandbox) }
   }
@@ -135,7 +135,7 @@ window.addEventListener("load", () => {
                  ["Revert to original code", () => revertCode(data)],
                  ["Reset sandbox (ctrl/cmd-esc)", () => resetSandbox(data.sandbox)]]
     if (!data.isHTML || !data.sandbox)
-      items.push(["Deactivate editor (ctrl-')", () => { closeCode(data) }])
+      items.push(["Deactivate editor (ctrl-down)", () => { closeCode(data) }])
     items.forEach(choice => menu.appendChild(elt("div", choice[0])))
     function click(e) {
       let target = e.target


### PR DESCRIPTION
@marijnh Going through your great book (thanks!).

This PR changes to `Ctrl-'` instead of `` Ctrl-` `` as the keyboard shortcut for leaving the editor in the examples, since many non-US keyboards do not have a backtick key, making it's impossible to enter the shortcut. For example my Swedish keyboard has none, and the only way to enter a backtick is as a diacritic for space (`Shift-'` followed by `Space`).

Hope that's OK. Let me know if another shortcut is more appropriate.