### PR TITLE
Remove comma separator from 'render_html.js' script and insert it in using CSS

### DIFF
--- a/html/css/ejs.css
+++ b/html/css/ejs.css
@@ -197,6 +197,10 @@ blockquote footer cite {
   font-style: italic;
 }
 
+blockquote footer cite:before {
+  content: ", ";
+}
+
 blockquote footer:before {
   content: '—';
   position: absolute;

--- a/src/render_html.js
+++ b/src/render_html.js
@@ -148,7 +148,7 @@ let renderer = {
   meta_quote_open() { return "\n\n<blockquote>" },
   meta_quote_close(token) {
     let {author, title} = token.args[0] || {}
-    return (author ? `\n\n<footer>${escape(author)}${title ? `, <cite>${escape(title)}</cite>` : ""}</footer>` : "") +
+    return (author ? `\n\n<footer>${escape(author)}${title ? `<cite>${escape(title)}</cite>` : ""}</footer>` : "") +
       "\n\n</blockquote>"
   },
   meta_keyname_open() { return "<span class=\"keyname\">" },


### PR DESCRIPTION
Not all languages use __,__ character as the comma.
So it's better to insert the comma separator between author's name and its citation's title (in quote blocks) using CSS tricks so, in order to change the comma character in the translation process, there is no need to change the _render_html.js_ script and only the stylesheets.