### PR TITLE
Use https for external links wherever possible

### DIFF
--- a/code/skillsharing/package.json
+++ b/code/skillsharing/package.json
@@ -9,7 +9,7 @@
           "licenses": [
                     {
                               "type": "MIT",
-                              "url": "http://opensource.org/licenses/MIT"
+                              "url": "https://opensource.org/licenses/MIT"
                     }
           ],
           "bugs": "https://github.com/marijnh/Eloquent-JavaScript/issues",
@@ -18,7 +18,7 @@
                     {
                               "name": "Marijn Haverbeke",
                               "email": "marijnh@gmail.com",
-                              "web": "http://marijnhaverbeke.nl"
+                              "web": "https://marijnhaverbeke.nl/"
                     }
           ],
           "repository": {

--- a/epub/content.opf.src
+++ b/epub/content.opf.src
@@ -9,7 +9,7 @@
     <dc:identifier id="pub-id">net.eloquentjavascript</dc:identifier>
     <dc:language>en-US</dc:language>
     <dc:rights>This work is shared with the public using the Attribution-NonCommercial 3.0 Unported (CC BY-NC 3.0) license.</dc:rights>
-    <link rel="cc:license" href="http://creativecommons.org/licenses/by-nc/3.0/"/>
+    <link rel="cc:license" href="https://creativecommons.org/licenses/by-nc/3.0/"/>
     <meta property="cc:attributionURL">https://eloquentjavascript.net/</meta>
     <meta property="dcterms:modified">2018-02-25T22:07:00Z</meta>
   </metadata>

--- a/epub/frontmatter.xhtml
+++ b/epub/frontmatter.xhtml
@@ -12,16 +12,16 @@
     <p>Written by Marijn Haverbeke.</p>
 
     <p>Licensed under
-    a <a href="http://creativecommons.org/licenses/by-nc/3.0/">Creative
+    a <a href="https://creativecommons.org/licenses/by-nc/3.0/">Creative
     Commons attribution-noncommercial license</a>. All code in this book
     may also be considered licensed under
-    an <a href="http://opensource.org/licenses/MIT">MIT license</a>.</p>
+    an <a href="https://opensource.org/licenses/MIT">MIT license</a>.</p>
 
     <p style="font-size: 80%">Illustrations by various artists: Cover
     and chapter illustrations by Madalina Tantareanu. Pixel art in
     Chapters 7 and 16 by Antonio Perdomo Pastor. Regular expression
     diagrams in Chapter 9 generated
-    with <a href="http://regexper.com">regexper.com</a> by Jeff
+    with <a href="https://regexper.com/">regexper.com</a> by Jeff
     Avallone. Village photograph in Chapter 11 by Fabrice Creuzot.
     Game concept for Chapter 15
     by <a href="http://lessmilk.com">Thomas Palef</a>.</p>
@@ -34,16 +34,16 @@
     alt="Holberton School" class="logo"/></a>. The second edition was
     supported by <a href="https://eloquentjavascript.net/backers.html">454 backers</a>, with
     significant contributions
-    from <a href="http://www.mozilla.org/en-US/"><img src="img/mozilla_mini.png"
+    from <a href="https://www.mozilla.org/en-US/"><img src="img/mozilla_mini.png"
     alt="Mozilla" class="logo"/></a>,
-    <a href="http://www.hackreactor.com/"><img src="img/hack_reactor_mini.png"
+    <a href="https://www.hackreactor.com/"><img src="img/hack_reactor_mini.png"
     alt="Hack Reactor" class="logo"/></a>,
-    and <a href="http://www.ghostery.com/"><img src="img/ghostery_mini.png"
+    and <a href="https://www.ghostery.com/"><img src="img/ghostery_mini.png"
     alt="Ghostery" class="logo"/></a>.</p>
 
     <p>A <a href="https://www.amazon.com/Eloquent-JavaScript-2nd-Ed-Introduction/dp/1593275846">paper
     version</a> of Eloquent JavaScript, including a bonus chapter, is
-    being brought out by <a href="http://www.nostarch.com/">No Starch
+    being brought out by <a href="https://nostarch.com/">No Starch
     Press</a>. They also sell a more polished EPUB version that
     includes the bonus chapter.</p>
 

--- a/html/author.html
+++ b/html/author.html
@@ -6,5 +6,5 @@
 
   <p>You can reach me at <a href="mailto:marijn@haverbeke.nl"
   property="email">marijn@haverbeke.nl</a>, or visit my web page, <a
-  href="http://marijnhaverbeke.nl" property="url">marijnhaverbeke.nl</a>.</p>
+  href="https://marijnhaverbeke.nl/" property="url">marijnhaverbeke.nl</a>.</p>
 </div>

--- a/html/author.json
+++ b/html/author.json
@@ -1,5 +1,5 @@
 {
     "name": "Marijn Haverbeke",
     "email": "marijn@haverbeke.nl",
-    "website": "http://marijnhaverbeke.nl"
+    "website": "https://marijnhaverbeke.nl/"
 }

--- a/html/author.txt
+++ b/html/author.txt
@@ -1,1 +1,1 @@
-My name is Marijn Haverbeke. You can email me at marijn@haverbeke.nl, or visit my website, http://marijnhaverbeke.nl .
+My name is Marijn Haverbeke. You can email me at marijn@haverbeke.nl, or visit my website, https://marijnhaverbeke.nl/ .

--- a/html/backers.html
+++ b/html/backers.html
@@ -24,7 +24,7 @@ possible.</p>
 <table>
   <tr>
     <th style="text-align: center">
-      <a href="http://www.mozilla.org/en-US/"><img class=logo src="img/mozilla.png" style="width: 8em" alt="Mozilla"></a>
+      <a href="https://www.mozilla.org/en-US/"><img class=logo src="img/mozilla.png" style="width: 8em" alt="Mozilla"></a>
     </th>
     <td class=amount>10,000 $</td>
     <td class=comment></td>
@@ -32,7 +32,7 @@ possible.</p>
 
   <tr>
     <th>
-      <a href="http://www.hackreactor.com/"><img class=logo src="img/hack_reactor.png" style="width: 10em" alt="Hack Reactor"></a>
+      <a href="https://www.hackreactor.com/"><img class=logo src="img/hack_reactor.png" style="width: 10em" alt="Hack Reactor"></a>
     </th>
     <td class=amount>7000 €</td>
     <td class=comment></td>
@@ -48,7 +48,7 @@ possible.</p>
 
   <tr>
     <th>
-      <a href="http://www.ghostery.com/"><img class=logo src="img/ghostery.png" style="width: 10em" alt="Ghostery"></a>
+      <a href="https://www.ghostery.com/"><img class=logo src="img/ghostery.png" style="width: 10em" alt="Ghostery"></a>
     </th>
     <td class=amount>1000 $</td>
     <td class=comment>Donation from dev team at Ghostery! Thanks for the awesome work!</td>
@@ -839,7 +839,7 @@ Go hard mate! =) </td>
       Andrew de Andrade
     </th>
     <td class=amount>25 $</td>
-    <td class=comment>Awesome work. I recommend your book to lots of people who are new to programming. I think it is easily one of the best books out there. Thank you and thank you on behalf of everyone I've recommended it to. 
+    <td class=comment>Awesome work. I recommend your book to lots of people who are new to programming. I think it is easily one of the best books out there. Thank you and thank you on behalf of everyone I've recommended it to.
 
 Also, thank you for Tern.js, CodeMirror and the Haskell code I have perused. I love it when people like you Brian Lonsdorf, Substack, Fogus and others help build bridges between JavaScript and functional programming programming languages like Haskell and Clojure, and grow the body of work in JavaScript code that use functional paradigms and idioms.
 
@@ -1567,7 +1567,7 @@ The practice-based introduction is what distinguishes this book from other JS bo
       Anonymous
     </th>
     <td class=amount>15 €</td>
-    <td class=comment>It would be incredibly great to be able to not only read the book, but use the book sandbox on iPhone. 
+    <td class=comment>It would be incredibly great to be able to not only read the book, but use the book sandbox on iPhone.
 With v1 AFAIK it was not practical and/or not working.
 An offline manifest would also be great for smartphones, in particular the (upcoming) Firefox OS based ones.</td>
   </tr>
@@ -1963,11 +1963,11 @@ I look forward to the results!</td>
       Bema
     </th>
     <td class=amount>10 €</td>
-    <td class=comment>Thanks for doing this excellent work, I read the first edition online and leaned a lot. 
+    <td class=comment>Thanks for doing this excellent work, I read the first edition online and leaned a lot.
 I would like to help translating it to Portuguese, I am Brazilian, so if by any chance you are contacted by other Brazilians willing to do the same job please put us in contact so we can build a working group for this task.
 
 Best wishes,
-Bema 
+Bema
 
 </td>
   </tr>
@@ -2744,7 +2744,7 @@ Thank you for all the work so far, looking forward to 2nd edition.</td>
 
   <tr>
     <th>
-      Jan 
+      Jan
     </th>
     <td class=amount>10 $</td>
     <td class=comment></td>
@@ -3356,7 +3356,7 @@ I am mighty impressed with current version and can only imagine what can you do 
 
   <tr>
     <th>
-      Ben Boarder 
+      Ben Boarder
     </th>
     <td class=amount>5 $</td>
     <td class=comment>The first edition of 'Eloquent JavaScript' helped me at the beginning of my development career so much, that I hope for the next generation of JavaScripters to gain the same solid skills. </td>

--- a/html/index.html
+++ b/html/index.html
@@ -25,7 +25,7 @@
 
   <p>This is a book about JavaScript, programming, and the wonders of
   the digital. You can read it online here, or get your own
-  <a href="http://www.amazon.com/gp/product/1593275846/ref=as_li_qf_sp_asin_il_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=1593275846&linkCode=as2&tag=marijhaver-20&linkId=VPXXXSRYC5COG5R5">paperback
+  <a href="https://www.amazon.com/gp/product/1593275846/ref=as_li_qf_sp_asin_il_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=1593275846&linkCode=as2&tag=marijhaver-20&linkId=VPXXXSRYC5COG5R5">paperback
   copy</a> of the <em>second</em> edition. A paper third edition is expected to be <a href="http://a-fwd.com/com=marijhaver-20&asin-com=1593279507">available</a> this November.</p>
 
   <p style="text-align: center; margin: 2em 0">
@@ -38,15 +38,15 @@
 
   <div style="font-size: 80%">
   <p>Licensed under
-  a <a href="http://creativecommons.org/licenses/by-nc/3.0/">Creative
+  a <a href="https://creativecommons.org/licenses/by-nc/3.0/">Creative
   Commons attribution-noncommercial license</a>. All code in this book
   may also be considered licensed under
-  an <a href="http://opensource.org/licenses/MIT">MIT license</a>.</p>
+  an <a href="https://opensource.org/licenses/MIT">MIT license</a>.</p>
 
   <p>Illustrations by various artists: Cover and chapter illustrations
   by Madalina Tantareanu. Pixel art in Chapters 7 and 16 by Antonio
   Perdomo Pastor. Regular expression diagrams in Chapter 9 generated
-  with <a href="http://regexper.com">regexper.com</a> by Jeff
+  with <a href="https://regexper.com">regexper.com</a> by Jeff
   Avallone. Village photograph in Chapter 11 by Fabrice Creuzot. Game
   concept for Chapter 15 by <a href="http://lessmilk.com">Thomas
   Palef</a>.</p>
@@ -57,11 +57,11 @@
   alt="Nextjournal" class=logo></a> and <a href="https://www.holbertonschool.com/"><img src="img/holberton.png" alt="Holberton School" class=logo></a>. The second edition
   was supported by <a href="backers.html">454 backers</a>, with
   significant contributions
-  from <a href="http://www.mozilla.org/en-US/"><img src="img/mozilla_mini.png"
+  from <a href="https://www.mozilla.org/en-US/"><img src="img/mozilla_mini.png"
   alt=Mozilla
-  class=logo></a>, <a href="http://www.hackreactor.com/"><img src="img/hack_reactor_mini.png"
+  class=logo></a>, <a href="https://www.hackreactor.com/"><img src="img/hack_reactor_mini.png"
   alt="Hack Reactor" class=logo></a>,
-  and <a href="http://www.ghostery.com/"><img src="img/ghostery_mini.png"
+  and <a href="https://www.ghostery.com/"><img src="img/ghostery_mini.png"
   alt="Ghostery" class=logo></a>.</p>
   </div>
 
@@ -111,7 +111,7 @@
 
   <p>A paper version of Eloquent JavaScript, including an additional
   chapter, is being brought out
-  by <a href="http://www.nostarch.com/ejs3">No Starch Press</a>. The
+  by <a href="https://www.nostarch.com/ejs3">No Starch Press</a>. The
   third edition should become available on paper somewhere in
   2018.</p>
 
@@ -131,8 +131,8 @@
   <h2>Translations of the second edition</h2>
 
   <ul class=translations>
-    <li><a href="http://to6esko.github.io/">Български (Bulgarian)</a></li>
-    <li><a href="http://braziljs.github.io/eloquente-javascript/">Português (Portuguese)</a></li>
+    <li><a href="https://to6esko.github.io/">Български (Bulgarian)</a></li>
+    <li><a href="https://braziljs.github.io/eloquente-javascript/">Português (Portuguese)</a></li>
     <li><a href="https://karmazzin.gitbooks.io/eloquentjavascript_ru/content/">Русский (Russian)</a></li>
   </ul>
 


### PR DESCRIPTION
The Portuguese translation of the book has some mixed-content warnings: https://braziljs.github.io/eloquente-javascript/ .. That needs to be fixed for proper reading experience.