### PR TITLE
Add function to save code snippets in localStore

### DIFF
--- a/html/js/ejs.js
+++ b/html/js/ejs.js
@@ -104,6 +104,7 @@ window.addEventListener("load", () => {
       clearTimeout(pollingScroll)
       pollingScroll = setTimeout(pollScroll, 500)
     })
+    editor.on("change", debounce(() => localStorage.setItem(codeId, editor.getValue()), 250))
     wrap.style.marginLeft = wrap.style.marginRight = -Math.min(article.offsetLeft, 100) + "px"
     setTimeout(() => editor.refresh(), 600)
     if (e) {
@@ -153,7 +154,6 @@ window.addEventListener("load", () => {
   }
 
   function runCode(data) {
-    saveCode(data)
     data.output.clear()
     let val = data.editor.getValue()
     getSandbox(data.sandbox, data.isHTML, box => {
@@ -167,11 +167,6 @@ window.addEventListener("load", () => {
       else
         box.run(val, data.output, data.meta)
     })
-  }
-
-  function saveCode(data) {
-    const codeId = data.orig.firstChild.id
-    localStorage.setItem(codeId, data.editor.getValue())
   }
 
   function closeCode(data) {
@@ -233,6 +228,14 @@ window.addEventListener("load", () => {
     if (bot < 50) {
       let newBot = wrap.getBoundingClientRect().bottom
       window.scrollBy(0, newBot - bot)
+    }
+  }
+
+  function debounce(fn, delay = 50) {
+    let timeout
+    return () => {
+      if (timeout) clearTimeout(timeout)
+      timeout = setTimeout(() => fn.apply(null, arguments), delay)
     }
   }
 })

--- a/html/js/ejs.js
+++ b/html/js/ejs.js
@@ -83,7 +83,8 @@ window.addEventListener("load", () => {
       localStorage.setItem("usedSandbox", "true")
     }
 
-    let code = node.textContent
+    const codeId = node.firstChild.id
+    let code = localStorage.getItem(codeId) || node.textContent
     let wrap = node.parentNode.insertBefore(elt("div", {"class": "editor-wrap"}), node)
     let editor = CodeMirror(div => wrap.insertBefore(div, wrap.firstChild), {
       value: code,
@@ -152,6 +153,7 @@ window.addEventListener("load", () => {
   }
 
   function runCode(data) {
+    saveCode(data)
     data.output.clear()
     let val = data.editor.getValue()
     getSandbox(data.sandbox, data.isHTML, box => {
@@ -165,6 +167,11 @@ window.addEventListener("load", () => {
       else
         box.run(val, data.output, data.meta)
     })
+  }
+
+  function saveCode(data) {
+    const codeId = data.orig.firstChild.id
+    localStorage.setItem(codeId, data.editor.getValue())
   }
 
   function closeCode(data) {


### PR DESCRIPTION
There were a few times while going through the book that I refreshed the page and lost my work. I put together a simple localStore mechanism for saving code snippets using their `c_ident` id. This commit is the bare minimum to get it working and I could easily extend it to a key binding/menu option if you'd like.

I'm not sure about using `firstChild` to get the node's `c_ident`. If this assumption isn't safe enough I can access it in a different way.

Thank you for the book; it has been a great resource for learning and teaching javascript!