### PR TITLE
Replace deprecated "licenses" property in skill-sharing website's package.json

### DIFF
--- a/code/skillsharing/package.json
+++ b/code/skillsharing/package.json
@@ -1,28 +1,28 @@
 {
-          "name": "ejs-skillsharing",
-          "version": "1.0.0",
-          "main": "skillsharing_server.js",
-          "description": "Skill-sharing website example from Eloquent JavaScript",
-          "dependencies": {
-                    "ecstatic": "^3.1.0"
-          },
-          "licenses": [
-                    {
-                              "type": "MIT",
-                              "url": "https://opensource.org/licenses/MIT"
-                    }
-          ],
-          "bugs": "https://github.com/marijnh/Eloquent-JavaScript/issues",
-          "homepage": "https://eloquentjavascript.net/21_skillsharing.html",
-          "maintainers": [
-                    {
-                              "name": "Marijn Haverbeke",
-                              "email": "marijnh@gmail.com",
-                              "web": "https://marijnhaverbeke.nl/"
-                    }
-          ],
-          "repository": {
-                    "type": "git",
-                    "url": "https://github.com/marijnh/Eloquent-JavaScript.git"
-          }
+  "name": "ejs-skillsharing",
+  "version": "1.0.0",
+  "main": "skillsharing_server.js",
+  "description": "Skill-sharing website example from Eloquent JavaScript",
+  "dependencies": {
+    "ecstatic": "^3.1.0"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://opensource.org/licenses/MIT"
+    }
+  ],
+  "bugs": "https://github.com/marijnh/Eloquent-JavaScript/issues",
+  "homepage": "https://eloquentjavascript.net/21_skillsharing.html",
+  "maintainers": [
+    {
+      "name": "Marijn Haverbeke",
+      "email": "marijnh@gmail.com",
+      "web": "https://marijnhaverbeke.nl/"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/marijnh/Eloquent-JavaScript.git"
+  }
 }

--- a/code/skillsharing/package.json
+++ b/code/skillsharing/package.json
@@ -6,12 +6,7 @@
   "dependencies": {
     "ecstatic": "^3.1.0"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://opensource.org/licenses/MIT"
-    }
-  ],
+  "license": "MIT",
   "bugs": "https://github.com/marijnh/Eloquent-JavaScript/issues",
   "homepage": "https://eloquentjavascript.net/21_skillsharing.html",
   "maintainers": [


### PR DESCRIPTION
(I was going to open an issue for this, but thought I might as well get some practice with opening pull requests, since I'm somewhat new to Git and GitHub.)

The code for the skill-sharing website contains a [now deprecated](https://docs.npmjs.com/files/package.json#license) `"licenses"` property, which leads to the following error when running `npm install`:
```
npm WARN ejs-skillsharing@1.0.0 No license field.
```

This pull request fixes this, by instead replacing `"licenses"` with a `"license"` field, containing an SPDX identifier for the MIT license (`"MIT"`). I also removed some weird indentation.

I'm not sure if this change would up the version number to `1.0.1` or not, so I left it at `1.0.0` for now.

Let me know if there's anything I should fix before this can be merged.