### PR TITLE
fix: add missing comma to range

### DIFF
--- a/code/solutions/09_1_regexp_golf.js
+++ b/code/solutions/09_1_regexp_golf.js
@@ -20,7 +20,7 @@ verify(/\s[.,:;]/,
        ["bad punctuation ."],
        ["escape the dot"]);
 
-verify(/\w{7}/,
+verify(/\w{7,}/,
        ["Siebentausenddreihundertzweiundzwanzig"],
        ["no", "three small words"]);
 


### PR DESCRIPTION
The current solution checks for an exact match of 7 characters, but It should be 7 or more characters.