### PR TITLE
Show Markdown as a language in the sidebar

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.md linguist-vendored=false
+*.md linguist-generated=false
+*.md linguist-documentation=false
+*.md linguist-detectable=true


### PR DESCRIPTION
The repository consists mostly of Markdown files, but this is not emphasized in the language overview. This PR will show Markdown as a language in the sidebar.

[Example repository](https://github.com/noahliechti/web3-interview-preparation) where markdown is shown as a language.