### PR TITLE
Fix grammatical error in Chapter 20 under 'Modules' section

### DIFF
--- a/20_node.md
+++ b/20_node.md
@@ -113,7 +113,7 @@ When importing a module—whether with `require` or `import`—Node has to resol
 
 {{index "node_modules directory", directory}}
 
-When a string that does not look like a relative or absolute path is imported, it is assumed to refer to either a built-in ((module)) or a module installed in a `node_modules` directory. For example, importing from `"node:fs"` will give you Node's built-in file system module. Importing `"robot"` might try to load the library found in `node_modules/robot/`. It's common to install such libraries is by using ((NPM)), which we'll return to in a moment.
+When a string that does not look like a relative or absolute path is imported, it is assumed to refer to either a built-in ((module)) or a module installed in a `node_modules` directory. For example, importing from `"node:fs"` will give you Node's built-in file system module. Importing `"robot"` might try to load the library found in `node_modules/robot/`. It's common to install such libraries using ((NPM)), which we'll return to in a moment.
 
 {{index "import keyword", "Node.js", "garble example"}}
 


### PR DESCRIPTION
**Description:**
I found and fixed a grammatical error in Chapter 20 titled "Node.js" under the subtitle "Modules." The sentence "It’s common to install such libraries is by using NPM, which we’ll return to in a moment." was incorrect due to the misplaced word "is". I corrected it to "It’s common to install such libraries using NPM, which we’ll return to in a moment."

**Steps to Reproduce:**

1. Go to Chapter 20 titled "Node.js".
2. Locate the section/subtitle "Modules".
3. Find the sentence: "It’s common to install such libraries is by using NPM, which we’ll return to in a moment."
4. Notice the grammatical error.

**Suggested Correction:**
The sentence was corrected to:

- "It’s common to install such libraries using NPM, which we’ll return to in a moment."

This change improves the grammatical structure and readability of the sentence.

**Pull Request:**
I have created this pull request to fix the issue.